### PR TITLE
Removed "seiyria-bootstrap-slider" from assets.xml as not existant

### DIFF
--- a/src/Resources/config/assets.yml
+++ b/src/Resources/config/assets.yml
@@ -54,7 +54,7 @@ components:
     - "/bower_components/morris.js"
     - "/bower_components/PACE"
     - "/bower_components/raphael"
-    - "/bower_components/seiyria-bootstrap-slider"
+#    - "/bower_components/seiyria-bootstrap-slider"
     - "/bower_components/select2"
 
 plugins:


### PR DESCRIPTION
When pulling version 1.5 this gives "composer update" errors, as the plugin is not existing in repo almasaeed2010/adminlte.
